### PR TITLE
Better validation error messages

### DIFF
--- a/stac-cli/CHANGELOG.md
+++ b/stac-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Better error messages for `stac validate` ([#190](https://github.com/stac-utils/stac-rs/pull/190))
+
 ## [0.0.3] - 2023-04-04
 
 Moved over from [stac-incubator-rs](https://github.com/gadomski/stac-incubator-rs) ([#142](https://github.com/stac-utils/stac-rs/pull/142))

--- a/stac-cli/Cargo.toml
+++ b/stac-cli/Cargo.toml
@@ -16,6 +16,7 @@ console = "0.15"
 indicatif = "0.17"
 reqwest = "0.11"
 serde = "1"
+serde_json = "1"
 stac = { version = "0.5", path = "../stac" }
 stac-async = { version = "0.4", path = "../stac-async" }
 stac-validate = { version = "0.1", path = "../stac-validate" }

--- a/stac-cli/src/args.rs
+++ b/stac-cli/src/args.rs
@@ -52,7 +52,7 @@ impl Command {
                 }
             }
             Validate { href } => {
-                let value: Value = stac_async::read(href).await?;
+                let value: serde_json::Value = stac_async::read_json(&href).await?;
                 let result = {
                     let value = value.clone();
                     tokio::task::spawn_blocking(move || value.validate()).await?

--- a/stac-cli/tests/data/collection-bad-temporal.json
+++ b/stac-cli/tests/data/collection-bad-temporal.json
@@ -1,0 +1,110 @@
+{
+  "id": "simple-collection",
+  "type": "Collection",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "stac_version": "1.0.0",
+  "description": "A simple collection demonstrating core catalog fields with links to a couple of items",
+  "title": "Simple Example Collection",
+  "providers": [
+    {
+      "name": "Remote Data, Inc",
+      "description": "Producers of awesome spatiotemporal assets",
+      "roles": [
+        "producer",
+        "processor"
+      ],
+      "url": "http://remotedata.io"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          172.91173669923782,
+          1.3438851951615003,
+          172.95469614953714,
+          1.3690476620161975
+        ]
+      ]
+    },
+    "temporal": [
+      [
+        "2020-12-11T22:38:32.125Z",
+        "2020-12-14T18:02:31.437Z"
+      ]
+    ]
+  },
+  "license": "CC-BY-4.0",
+  "summaries": {
+    "platform": [
+      "cool_sat1",
+      "cool_sat2"
+    ],
+    "constellation": [
+      "ion"
+    ],
+    "instruments": [
+      "cool_sensor_v1",
+      "cool_sensor_v2"
+    ],
+    "gsd": {
+      "minimum": 0.512,
+      "maximum": 0.66
+    },
+    "eo:cloud_cover": {
+      "minimum": 1.2,
+      "maximum": 1.2
+    },
+    "proj:epsg": {
+      "minimum": 32659,
+      "maximum": 32659
+    },
+    "view:sun_elevation": {
+      "minimum": 54.9,
+      "maximum": 54.9
+    },
+    "view:off_nadir": {
+      "minimum": 3.8,
+      "maximum": 3.8
+    },
+    "view:sun_azimuth": {
+      "minimum": 135.7,
+      "maximum": 135.7
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "./collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    },
+    {
+      "rel": "item",
+      "href": "./simple-item.json",
+      "type": "application/geo+json",
+      "title": "Simple Item"
+    },
+    {
+      "rel": "item",
+      "href": "./core-item.json",
+      "type": "application/geo+json",
+      "title": "Core Item"
+    },
+    {
+      "rel": "item",
+      "href": "./extended-item.json",
+      "type": "application/geo+json",
+      "title": "Extended Item"
+    },
+    {
+      "rel": "self",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0/examples/collection.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/stac-validate/CHANGELOG.md
+++ b/stac-validate/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Validation for `serde_json::Value` ([#190](https://github.com/stac-utils/stac-rs/pull/190))
+
 ## [0.1.0] - 2023-06-27
 
 Initial release.

--- a/stac-validate/src/validate.rs
+++ b/stac-validate/src/validate.rs
@@ -145,3 +145,25 @@ impl ValidateCore for ItemCollection {
         validator.validate_item_collection(value)
     }
 }
+
+impl Validate for Value {}
+
+impl ValidateCore for Value {
+    fn validate_core_json(value: &Value, validator: &Validator) -> Result<()> {
+        if let Some(type_) = value.get("type") {
+            if let Some(type_) = type_.as_str() {
+                match type_ {
+                    "Feature" => validator.validate_item(value),
+                    "Collection" => validator.validate_collection(value),
+                    "Catalog" => validator.validate_catalog(value),
+                    "FeatureCollection" => validator.validate_item_collection(value),
+                    _ => Err(stac::Error::UnknownType(type_.to_string()).into()),
+                }
+            } else {
+                Err(stac::Error::InvalidTypeField(type_.clone()).into())
+            }
+        } else {
+            Err(stac::Error::MissingType.into())
+        }
+    }
+}


### PR DESCRIPTION
## Closes

- Closes #185 

## Description

Implements `Validate` for `serde_json::Value`, then only parse the JSON before starting validation.

New error message:

```shell
$ stac validate stac-cli/tests/data/collection-bad-temporal.json
Validation error at /extent/temporal: [["2020-12-11T22:38:32.125Z","2020-12-14T18:02:31.437Z"]] is not of type "object"
ERROR: validation errors
```

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
