### PR TITLE
Deprecate, don't remove, intersects_bbox

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,9 +8,10 @@
 4. Update the package's `Cargo.toml` file accordingly, and update the other packages' `Cargo.toml` if they depend on this package.
 5. Scan the package's README for references to version numbers, and update any that are needed.
 6. Update the package's CHANGELOG with a new section for the new version. Don't forget to update the links at the bottom, too.
-7. Test the release with `cargo release -p {package name}`. By default, this does a dry-run, so it won't actually do anything.
-8. Use the normal pull request workflow to merge your branch.
-9. Once merged, run `cargo release --execute` to do the release. Use the same `-p` flags as you did during the dry run.
+7. If it's a breaking release, search for any deprecated functions that should be removed.
+8. Test the release with `cargo release -p {package name}`. By default, this does a dry-run, so it won't actually do anything.
+9. Use the normal pull request workflow to merge your branch.
+10. Once merged, run `cargo release --execute` to do the release. Use the same `-p` flags as you did during the dry run.
 
 ## After-the-fact releases
 

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -10,9 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `Item.intersects` ([#202](https://github.com/stac-utils/stac-rs/pull/202))
 
-### Removed
+### Deprecated
 
-- `Item.intersects_bbox` ([#202](https://github.com/stac-utils/stac-rs/pull/202))
+- `Item.intersects_bbox` ([#204](https://github.com/stac-utils/stac-rs/pull/204))
 
 ## [0.5.1] - 2023-09-14
 

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -239,6 +239,34 @@ impl Item {
         }
     }
 
+    /// Returns true if this item's geometry intersects the provided bounding box.
+    ///
+    /// DEPRECATED Use `intersects` instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use stac::Item;
+    /// use geojson::{Geometry, Value};
+    ///
+    /// let mut item = Item::new("an-id");
+    /// item.set_geometry(Some(Geometry::new(Value::Point(vec![-105.1, 41.1]))));
+    /// let bbox = stac::geo::bbox(&vec![-106.0, 41.0, -105.0, 42.0]).unwrap();
+    /// assert!(item.intersects_bbox(bbox).unwrap());
+    /// ```
+    #[cfg(feature = "geo")]
+    #[deprecated(since = "0.5.2", note = "Use intersects instead")]
+    pub fn intersects_bbox(&self, bbox: geo::Rect) -> Result<bool> {
+        use geo::Intersects;
+
+        if let Some(geometry) = self.geometry.clone() {
+            let geometry: geo::Geometry = geometry.try_into()?;
+            Ok(geometry.intersects(&bbox))
+        } else {
+            Ok(false)
+        }
+    }
+
     /// Returns true if this item's datetime (or start and end datetimes)
     /// intersects the provided datetime.
     ///


### PR DESCRIPTION
## Related to

- I removed it in https://github.com/stac-utils/stac-rs/pull/202 but that was too aggressive.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
