### PR TITLE
Validate collections endpoint

### DIFF
--- a/stac-cli/CHANGELOG.md
+++ b/stac-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Validation for the collections endpoint ([#208](https://github.com/stac-utils/stac-rs/pull/208))
+
 ## [0.0.5] - 2023-10-11
 
 ### Added

--- a/stac-cli/src/command.rs
+++ b/stac-cli/src/command.rs
@@ -83,9 +83,15 @@ pub enum Command {
         compact: bool,
     },
 
-    /// Validates a STAC object using json-schema validation.
+    /// Validates a STAC object or API endpoint using json-schema validation.
     Validate {
-        /// The href of the STAC object.
+        /// The href of the STAC object or endpoint.
+        ///
+        /// The validator will make some decisions depending on what type of
+        /// data is returned from the href. If it's a STAC Catalog, Collection,
+        /// or Item, that object will be validated. If its a collections
+        /// endpoint from a STAC API, all collections will be validated.
+        /// Additional behavior TBD.
         href: String,
     },
 }

--- a/stac-cli/src/commands/validate.rs
+++ b/stac-cli/src/commands/validate.rs
@@ -1,12 +1,55 @@
-use crate::Result;
-use stac_validate::Validate;
+use crate::{Error, Result};
+use stac_validate::{Validate, Validator};
 
 pub async fn validate(href: &str) -> Result<()> {
     let value: serde_json::Value = stac_async::read_json(href).await?;
-    let result = {
-        let value = value.clone();
-        tokio::task::spawn_blocking(move || value.validate()).await?
-    };
+    if let Some(map) = value.as_object() {
+        if map.contains_key("type") {
+            let value = value.clone();
+            let result = tokio::task::spawn_blocking(move || value.validate()).await?;
+            print_result(result).map_err(Error::from)
+        } else if let Some(collections) = map
+            .get("collections")
+            .and_then(|collections| collections.as_array())
+        {
+            let collections = collections.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let mut errors = Vec::new();
+                let mut validator = Validator::new();
+                let num_collections = collections.len();
+                let mut valid_collections = 0;
+                for collection in collections {
+                    if let Some(id) = collection.get("id").and_then(|id| id.as_str()) {
+                        println!("== Validating {}", id);
+                    }
+                    let result = validator.validate(collection);
+                    match print_result(result) {
+                        Ok(()) => valid_collections += 1,
+                        Err(err) => errors.push(err),
+                    }
+                    println!("")
+                }
+                println!(
+                    "{}/{} collections are valid",
+                    valid_collections, num_collections
+                );
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(Error::ValidationGroup(errors))
+                }
+            })
+            .await?;
+            result
+        } else {
+            todo!()
+        }
+    } else {
+        todo!()
+    }
+}
+
+pub fn print_result(result: stac_validate::Result<()>) -> stac_validate::Result<()> {
     match result {
         Ok(()) => {
             println!("OK!");
@@ -16,11 +59,11 @@ pub async fn validate(href: &str) -> Result<()> {
             for err in &errors {
                 println!("Validation error at {}: {}", err.instance_path, err)
             }
-            Err(stac_validate::Error::Validation(errors).into())
+            Err(stac_validate::Error::Validation(errors))
         }
         Err(err) => {
             println!("Error while validating: {}", err);
-            Err(err.into())
+            Err(err)
         }
     }
 }

--- a/stac-cli/src/error.rs
+++ b/stac-cli/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
 
     #[error(transparent)]
     TokioJoinError(#[from] tokio::task::JoinError),
+
+    #[error("many validation errors")]
+    ValidationGroup(Vec<stac_validate::Error>),
 }
 
 impl Error {


### PR DESCRIPTION
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
