### PR TITLE
Add `ApiClient::with_client`

### DIFF
--- a/stac-async/CHANGELOG.md
+++ b/stac-async/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `ApiClient::with_client` ([#227](https://github.com/stac-utils/stac-rs/pull/227))
+
 ### Removed
 
 - Downloading (use [stac-asset](https://github.com/stac-utils/stac-asset) instead) ([#194](https://github.com/stac-utils/stac-rs/pull/194))

--- a/stac-async/src/api_client.rs
+++ b/stac-async/src/api_client.rs
@@ -28,8 +28,24 @@ impl ApiClient {
     /// ```
     pub fn new(url: &str) -> Result<ApiClient> {
         // TODO support HATEOS (aka look up the urls from the root catalog)
+        ApiClient::with_client(Client::new(), url)
+    }
+
+    /// Creates a new API client with the given [Client].
+    ///
+    /// Useful if you want to customize the behavior of the underlying `Client`,
+    /// as documented in [Client::new].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use stac_async::{Client, ApiClient};
+    /// let client = Client::new();
+    /// let api_client = ApiClient::with_client(client, "https://earth-search.aws.element84.com/v1/").unwrap();
+    /// ```
+    pub fn with_client(client: Client, url: &str) -> Result<ApiClient> {
         Ok(ApiClient {
-            client: Client::new(),
+            client,
             channel_buffer: DEFAULT_CHANNEL_BUFFER,
             url_builder: UrlBuilder::new(url)?,
         })


### PR DESCRIPTION
## Closes

- Closes #219

## Description

Adds a `with_client` method to allow setting up an `ApiClient` with custom behavior.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
