### PR TITLE
Add more proj fields to gdal item creation

### DIFF
--- a/stac-cli/CHANGELOG.md
+++ b/stac-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.0.7] - 2024-04-11
+
 ### Added
 
 - `stac validate` can take from stdin ([#236](https://github.com/stac-utils/stac-rs/pull/236))
@@ -45,7 +47,8 @@ Moved over from [stac-incubator-rs](https://github.com/gadomski/stac-incubator-r
 - Downloading ([#142](https://github.com/stac-utils/stac-rs/pull/142), [#152](https://github.com/stac-utils/stac-rs/pull/152))
 - Validation ([#155](https://github.com/stac-utils/stac-rs/pull/155))
 
-[Unreleased]: https://github.com/stac-utils/stac-rs/compare/stac-cli-v0.0.6..main
+[Unreleased]: https://github.com/stac-utils/stac-rs/compare/stac-cli-v0.0.7..main
+[0.0.7]: https://github.com/stac-utils/stac-rs/compare/stac-cli-v0.0.6..stac-cli-v0.0.7
 [0.0.6]: https://github.com/stac-utils/stac-rs/compare/stac-cli-v0.0.5..stac-cli-v0.0.6
 [0.0.5]: https://github.com/stac-utils/stac-rs/compare/stac-cli-v0.0.4..stac-cli-v0.0.5
 [0.0.4]: https://github.com/stac-utils/stac-rs/compare/stac-cli-v0.0.3..stac-cli-v0.0.4

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - The projection and raster extensions, the `Extension` trait, and the `Fields` trait ([#234](https://github.com/stac-utils/stac-rs/pull/234))
 - `stac::item::Builder` ([#237](https://github.com/stac-utils/stac-rs/pull/237))
-- The `gdal` feature ([#232](https://github.com/stac-utils/stac-rs/pull/232))
+- The `gdal` feature ([#232](https://github.com/stac-utils/stac-rs/pull/232), [#240](https://github.com/stac-utils/stac-rs/pull/240))
 - `Bounds` ([#232](https://github.com/stac-utils/stac-rs/pull/232))
 
 ### Changed

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-04-11
+
 ### Added
 
 - The projection and raster extensions, the `Extension` trait, and the `Fields` trait ([#234](https://github.com/stac-utils/stac-rs/pull/234))
@@ -269,7 +271,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Initial release.
 
-[Unreleased]: https://github.com/stac-utils/stac-rs/compare/stac-v0.5.3...main
+[Unreleased]: https://github.com/stac-utils/stac-rs/compare/stac-v0.6.0...main
+[0.6.0]: https://github.com/stac-utils/stac-rs/compare/stac-v0.5.3...stac-v0.6.0
 [0.5.3]: https://github.com/stac-utils/stac-rs/compare/stac-v0.5.2...stac-v0.5.3
 [0.5.2]: https://github.com/stac-utils/stac-rs/compare/stac-v0.5.1...stac-v0.5.2
 [0.5.1]: https://github.com/stac-utils/stac-rs/compare/stac-v0.5.0...stac-v0.5.1

--- a/stac/src/extensions/projection.rs
+++ b/stac/src/extensions/projection.rs
@@ -37,7 +37,7 @@ pub struct Projection {
 
     /// Number of pixels in Y and X directions for the default grid
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shape: Option<Vec<f64>>,
+    pub shape: Option<Vec<usize>>,
 
     /// The affine transformation coefficients for the default grid
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Closes

- Closes #239

## Description

_Technically_ a breaking change to the `Projection::shape` type, but we're going to just skate past it b/c its new (I'll pretend it a bugfix).

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
