### PR TITLE
Allow stdin for stac-cli sort

### DIFF
--- a/stac-cli/CHANGELOG.md
+++ b/stac-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `stac sort` can take stdin ([#241](https://github.com/stac-utils/stac-rs/pull/241))
+
 ## [0.0.7] - 2024-04-11
 
 ### Added

--- a/stac-cli/src/command.rs
+++ b/stac-cli/src/command.rs
@@ -116,7 +116,9 @@ pub enum Command {
     /// Sorts the fields of STAC object.
     Sort {
         /// The href of the STAC object.
-        href: String,
+        ///
+        /// If this is not provided, will read from standard input.
+        href: Option<String>,
 
         /// If true, don't pretty-print the output
         #[arg(short, long)]
@@ -199,7 +201,7 @@ impl Command {
                 let search = get_search.try_into()?;
                 crate::commands::search(&href, search, max_items, stream, !(compact | stream)).await
             }
-            Sort { href, compact } => crate::commands::sort(&href, compact).await,
+            Sort { href, compact } => crate::commands::sort(href.as_deref(), compact).await,
             Validate { href } => crate::commands::validate(href.as_deref()).await,
         }
     }

--- a/stac-cli/src/commands/sort.rs
+++ b/stac-cli/src/commands/sort.rs
@@ -1,7 +1,12 @@
 use crate::Result;
+use stac::Value;
 
-pub async fn sort(href: &str, compact: bool) -> Result<()> {
-    let value: stac::Value = stac_async::read_json(href).await?;
+pub async fn sort(href: Option<&str>, compact: bool) -> Result<()> {
+    let value: Value = if let Some(href) = href {
+        stac_async::read_json(href).await?
+    } else {
+        serde_json::from_reader(std::io::stdin())?
+    };
     let output = if compact {
         serde_json::to_string(&value).unwrap()
     } else {

--- a/stac-cli/tests/command.rs
+++ b/stac-cli/tests/command.rs
@@ -27,3 +27,14 @@ fn validate_stdin() {
         .unwrap();
     command.arg("validate").write_stdin(item).assert().success();
 }
+
+#[test]
+fn sort_stdin() {
+    let mut command = Command::cargo_bin("stac").unwrap();
+    let mut item = String::new();
+    File::open("data/simple-item.json")
+        .unwrap()
+        .read_to_string(&mut item)
+        .unwrap();
+    command.arg("sort").write_stdin(item).assert().success();
+}


### PR DESCRIPTION
## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
