### PR TITLE
Add wkb feature and GeoparquetItem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         args:
           - "-p stac"
           - "-p stac -F reqwest"
+          - "-p stac -F wkb"
           - "-p stac-api"
           - "-p stac -p stac-api -F geo"
           - "-p stac-async"

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `stac::datetime::Interval` ([#252](https://github.com/stac-utils/stac-rs/pull/252))
 - `TryFrom<Feature>` and `TryInto<Feature>` for `Item` ([#255](https://github.com/stac-utils/stac-rs/pull/255))
+- `wkb` feature and `GeoparquetItem` ([#260](https://github.com/stac-utils/stac-rs/pull/260))
 
 ### Fixed
 

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["science", "data-structures"]
 gdal = ["dep:gdal", "dep:gdal-sys", "dep:log"]
 geo = ["dep:geo"]
 reqwest = ["dep:reqwest"]
+wkb = ["dep:wkb", "geo", "dep:log"]
 
 [dependencies]
 chrono = "0.4"
@@ -31,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "1"
 url = "2"
+wkb = { version = "0.7", optional = true }
 
 [dev-dependencies]
 assert-json-diff = "2"

--- a/stac/README.md
+++ b/stac/README.md
@@ -110,6 +110,33 @@ Then, you can set an item's geometry and bounding box at the same time:
 }
 ```
 
+### wkb
+
+Use the `wkb` feature to convert items to and from their [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) forms.
+
+```toml
+[dependencies]
+stac = { version = "0.7", features = ["wkb"] }
+```
+
+Then:
+
+```rust
+#[cfg(feature = "wkb")]
+{
+    use stac::Item;
+    use geojson::{Geometry, Value};
+
+    let geometry = Geometry::new(Value::Point(vec![
+        -105.1, 41.1,
+    ]));
+    let mut item = Item::new("an-id");
+    item.set_geometry(geometry).unwrap();
+    let geoparquet_item = item.into_geoparquet_item(true).unwrap();
+    let item = Item::try_from(geoparquet_item).unwrap();
+}
+```
+
 ## Other info
 
 This crate is part of the [stac-rs](https://github.com/stac-utils/stac-rs) monorepo, see its README for contributing and license information.

--- a/stac/src/error.rs
+++ b/stac/src/error.rs
@@ -20,7 +20,6 @@ pub enum Error {
     GdalNotEnabled,
 
     /// [geojson::Error]
-    #[cfg(feature = "geo")]
     #[error(transparent)]
     Geojson(#[from] geojson::Error),
 
@@ -31,6 +30,11 @@ pub enum Error {
     /// Returned when the `type` field of a STAC object is not a [String].
     #[error("invalid \"type\" field: {0}")]
     InvalidTypeField(JsonValue),
+
+    /// Returned when a property name conflicts with a top-level STAC field, or
+    /// it's an invalid top-level field name.
+    #[error("invalid attribute name: {0}")]
+    InvalidAttribute(String),
 
     /// Returned when a STAC object has the wrong type field.
     #[error("incorrect type: expected={expected}, actual={actual}")]
@@ -60,6 +64,14 @@ pub enum Error {
     /// Returned when an object is expected to have an href, but it doesn't.
     #[error("object has no href")]
     MissingHref,
+
+    /// Returned when an item is expected to have a geometry but doesn't.
+    #[error("item has no geometry")]
+    MissingGeometry,
+
+    /// Returned when an item is expected to have a bbox but doesn't.
+    #[error("item has no bbox")]
+    MissingBbox,
 
     /// This value is not an item.
     #[error("value is not an item")]
@@ -101,4 +113,28 @@ pub enum Error {
     /// [url::ParseError]
     #[error(transparent)]
     Url(#[from] url::ParseError),
+
+    /// [wkb::WKBReadError]
+    #[cfg(feature = "wkb")]
+    #[error("wkb read error: {0:?}")]
+    WkbRead(wkb::WKBReadError),
+
+    /// [wkb::WKBWriteError]
+    #[cfg(feature = "wkb")]
+    #[error("wkb write error: {0:?}")]
+    WkbWrite(wkb::WKBWriteError),
+}
+
+#[cfg(feature = "wkb")]
+impl From<wkb::WKBWriteError> for Error {
+    fn from(err: wkb::WKBWriteError) -> Error {
+        Error::WkbWrite(err)
+    }
+}
+
+#[cfg(feature = "wkb")]
+impl From<wkb::WKBReadError> for Error {
+    fn from(err: wkb::WKBReadError) -> Error {
+        Error::WkbRead(err)
+    }
 }


### PR DESCRIPTION
## Related to

- Helps #256

## Description

Going to and from **stac-geoparquet** structure requires a little logic, none of which actually depends on **geoparquet** or **geoarrow**, just **wkb**. This PR adds those conversions with a new `wkb` feature.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
