### PR TITLE
Rename GeoparquetItem to FlatItem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         args:
           - "-p stac"
           - "-p stac -F reqwest"
-          - "-p stac -F wkb"
           - "-p stac-api"
           - "-p stac -p stac-api -F geo"
           - "-p stac-async"

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `stac::datetime::Interval` ([#252](https://github.com/stac-utils/stac-rs/pull/252))
 - `TryFrom<Feature>` and `TryInto<Feature>` for `Item` ([#255](https://github.com/stac-utils/stac-rs/pull/255))
-- `wkb` feature and `GeoparquetItem` ([#260](https://github.com/stac-utils/stac-rs/pull/260), [#263](https://github.com/stac-utils/stac-rs/pull/263))
+- `FlatItem` ([#260](https://github.com/stac-utils/stac-rs/pull/260), [#263](https://github.com/stac-utils/stac-rs/pull/263), [#275](https://github.com/stac-utils/stac-rs/pull/275))
 - Authentication extension ([#268](https://github.com/stac-utils/stac-rs/pull/268))
 - Electro-Optical extension ([#271](https://github.com/stac-utils/stac-rs/pull/271))
 

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -11,10 +11,9 @@ keywords = ["geospatial", "stac", "metadata", "geo", "raster"]
 categories = ["science", "data-structures"]
 
 [features]
-gdal = ["dep:gdal", "dep:gdal-sys", "dep:log"]
+gdal = ["dep:gdal", "dep:gdal-sys"]
 geo = ["dep:geo"]
 reqwest = ["dep:reqwest"]
-wkb = ["dep:geozero", "geozero/with-wkb", "geo", "dep:log"]
 
 [dependencies]
 chrono = "0.4"
@@ -26,8 +25,7 @@ gdal-sys = { version = "0.9", optional = true, features = [
 ] } # we use bindgen b/c the gdal crate doesn't support GDAL 3.8 as of this writing, and we depend on gdal-sys for build script usage
 geo = { version = "0.28", optional = true }
 geojson = { version = "0.24" }
-geozero = { version = "0.13", optional = true }
-log = { version = "0.4", optional = true }
+log = { version = "0.4" }
 reqwest = { version = "0.12", optional = true, features = ["json", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/stac/README.md
+++ b/stac/README.md
@@ -110,33 +110,6 @@ Then, you can set an item's geometry and bounding box at the same time:
 }
 ```
 
-### wkb
-
-Use the `wkb` feature to convert items to and from their [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) forms.
-
-```toml
-[dependencies]
-stac = { version = "0.7", features = ["wkb"] }
-```
-
-Then:
-
-```rust
-#[cfg(feature = "wkb")]
-{
-    use stac::Item;
-    use geojson::{Geometry, Value};
-
-    let geometry = Geometry::new(Value::Point(vec![
-        -105.1, 41.1,
-    ]));
-    let mut item = Item::new("an-id");
-    item.set_geometry(geometry).unwrap();
-    let geoparquet_item = item.into_geoparquet_item(true).unwrap();
-    let item = Item::try_from(geoparquet_item).unwrap();
-}
-```
-
 ## Other info
 
 This crate is part of the [stac-rs](https://github.com/stac-utils/stac-rs) monorepo, see its README for contributing and license information.

--- a/stac/src/error.rs
+++ b/stac/src/error.rs
@@ -23,11 +23,6 @@ pub enum Error {
     #[error(transparent)]
     Geojson(#[from] geojson::Error),
 
-    /// [geozero::error::GeozeroError]
-    #[cfg(feature = "wkb")]
-    #[error(transparent)]
-    Geozero(#[from] geozero::error::GeozeroError),
-
     /// [std::io::Error]
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -69,14 +64,6 @@ pub enum Error {
     /// Returned when an object is expected to have an href, but it doesn't.
     #[error("object has no href")]
     MissingHref,
-
-    /// Returned when an item is expected to have a geometry but doesn't.
-    #[error("item has no geometry")]
-    MissingGeometry,
-
-    /// Returned when an item is expected to have a bbox but doesn't.
-    #[error("item has no bbox")]
-    MissingBbox,
 
     /// This value is not an item.
     #[error("value is not an item")]

--- a/stac/src/lib.rs
+++ b/stac/src/lib.rs
@@ -146,7 +146,7 @@ pub use {
     fields::Fields,
     href::{href_to_url, Href},
     io::{read, read_json},
-    item::{Item, Properties, ITEM_TYPE},
+    item::{FlatItem, Item, Properties, ITEM_TYPE},
     item_collection::{ItemCollection, ITEM_COLLECTION_TYPE},
     link::{Link, Links},
     value::Value,


### PR DESCRIPTION
## Related to

- Discovered while working #256 

## Description

Turns out we just want the flat structure, nothing specific to stac-geoparquet.

## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
