### PR TITLE
Fix axis mapping strategy for gdal wgs84 bounds/geom

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Removed unnecessary qualifications ([#251](https://github.com/stac-utils/stac-rs/pull/251))
+- Axis ordering for WGS84 bounds+geometries ([#277](https://github.com/stac-utils/stac-rs/pull/277))
 
 ## [0.7.0] - 2024-04-29
 


### PR DESCRIPTION
## Description

We got bit by https://gdal.org/tutorials/osr_api_tut.html#crs-and-axis-order

## Checklist

- [x] Unit tests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
