### PR TITLE
Bump gdal crates

### DIFF
--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -17,12 +17,8 @@ reqwest = ["dep:reqwest"]
 
 [dependencies]
 chrono = "0.4"
-gdal = { version = "0.16", optional = true, features = [
-    "bindgen",
-] } # we use bindgen b/c the gdal crate doesn't support GDAL 3.8 as of this writing
-gdal-sys = { version = "0.9", optional = true, features = [
-    "bindgen",
-] } # we use bindgen b/c the gdal crate doesn't support GDAL 3.8 as of this writing, and we depend on gdal-sys for build script usage
+gdal = { version = "0.17", optional = true }
+gdal-sys = { version = "0.10", optional = true }
 geo = { version = "0.28", optional = true }
 geojson = { version = "0.24" }
 log = { version = "0.4" }

--- a/stac/src/extensions/projection.rs
+++ b/stac/src/extensions/projection.rs
@@ -76,17 +76,16 @@ impl Projection {
     /// ```
     #[cfg(feature = "gdal")]
     pub fn wgs84_bounds(&self) -> crate::Result<Option<crate::Bounds>> {
-        use gdal::spatial_ref::{CoordTransform, SpatialRef};
-        use gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER;
+        use gdal::spatial_ref::{AxisMappingStrategy, CoordTransform, SpatialRef};
 
         if let Some(bbox) = self.bbox.as_ref() {
             if bbox.len() != 4 {
                 return Ok(None);
             }
             if let Some(spatial_ref) = self.spatial_ref()? {
-                let wgs84 = SpatialRef::from_epsg(4326)?;
+                let mut wgs84 = SpatialRef::from_epsg(4326)?;
                 // Ensure we're lon then lat
-                wgs84.set_axis_mapping_strategy(OAMS_TRADITIONAL_GIS_ORDER);
+                wgs84.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
                 let coord_transform = CoordTransform::new(&spatial_ref, &wgs84)?;
                 let bounds =
                     coord_transform.transform_bounds(&[bbox[0], bbox[1], bbox[2], bbox[3]], 21)?;

--- a/stac/src/gdal.rs
+++ b/stac/src/gdal.rs
@@ -139,7 +139,7 @@ fn update_asset(
         }
     }
     let count = dataset.raster_count();
-    let mut bands = Vec::with_capacity(count.try_into()?);
+    let mut bands = Vec::with_capacity(count);
     for i in 1..=count {
         let band = dataset.rasterband(i)?;
         bands.push(Band {


### PR DESCRIPTION

## Closes

- Closes (supersedes) #282 and #283 

## Description

Also remove the bindgen, since newer gdal crates have moar bindings. We could maybe do to add some doc notes about building with `-F gdal/bindgen` if out-of-the-box building doesn't work, but it's only speculative at this point.
