### PR TITLE
Use `DateTime<Utc>` instead of `String` for datetimes

### DIFF
--- a/pgstac/src/client.rs
+++ b/pgstac/src/client.rs
@@ -576,7 +576,7 @@ mod tests {
         let mut item = Item::new("an-id");
         item.collection = Some("collection-id".to_string());
         item.geometry = Some(longmont());
-        item.properties.datetime = Some("2023-01-07T00:00:00Z".to_string());
+        item.properties.datetime = Some("2023-01-07T00:00:00Z".parse().unwrap());
         client.add_item(item.clone()).await.unwrap();
         let mut search = Search::default();
         search.items.datetime = Some("2023-01-07T00:00:00Z".to_string());
@@ -638,11 +638,11 @@ mod tests {
         client.add_collection(collection).await.unwrap();
         let mut item = Item::new("an-id");
         item.collection = Some("collection-id".to_string());
-        item.properties.datetime = Some("2023-01-08T00:00:00Z".to_string());
+        item.properties.datetime = Some("2023-01-08T00:00:00Z".parse().unwrap());
         item.geometry = Some(longmont());
         client.add_item(item.clone()).await.unwrap();
         item.id = "another-id".to_string();
-        item.properties.datetime = Some("2023-01-07T00:00:00Z".to_string());
+        item.properties.datetime = Some("2023-01-07T00:00:00Z".parse().unwrap());
         client.add_item(item).await.unwrap();
         let mut search = Search::default();
         search.items.limit = Some(1);

--- a/stac-api/src/items.rs
+++ b/stac-api/src/items.rs
@@ -226,7 +226,7 @@ impl Items {
     /// assert!(search.datetime_matches(&item).unwrap());
     /// search.datetime = Some("../2023-10-09T00:00:00Z".to_string());
     /// assert!(!search.datetime_matches(&item).unwrap());
-    /// item.properties.datetime = Some("2023-10-08T00:00:00Z".to_string());
+    /// item.properties.datetime = Some("2023-10-08T00:00:00Z".parse().unwrap());
     /// assert!(search.datetime_matches(&item).unwrap());
     /// ```
     pub fn datetime_matches(&self, item: &Item) -> Result<bool> {

--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Use `DateTime<Utc>` instead of `String` for datetimes ([#297](https://github.com/stac-utils/stac-rs/pull/297))
+
 ## [0.8.0] - 2024-08-12
 
 ### Added

--- a/stac/Cargo.toml
+++ b/stac/Cargo.toml
@@ -16,7 +16,7 @@ geo = ["dep:geo"]
 reqwest = ["dep:reqwest"]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 gdal = { version = "0.17", optional = true }
 gdal-sys = { version = "0.10", optional = true }
 geo = { version = "0.28", optional = true }

--- a/stac/examples/bands-v1.1.0-beta.1.json
+++ b/stac/examples/bands-v1.1.0-beta.1.json
@@ -4,7 +4,7 @@
     "id": "bands-migration",
     "geometry": null,
     "properties": {
-        "datetime": "2024-08-11T16:07:32.766181+00:00"
+        "datetime": "2024-08-11T16:07:32.766181Z"
     },
     "links": [],
     "assets": {


### PR DESCRIPTION
## Checklist

- [x] Unit tests
- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG
