### PR TITLE
Make `io::read_json` pub(crate)

### DIFF
--- a/stac/CHANGELOG.md
+++ b/stac/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use `DateTime<Utc>` instead of `String` for datetimes ([#297](https://github.com/stac-utils/stac-rs/pull/297))
 - Add `Href.clear_href` ([#299](https://github.com/stac-utils/stac-rs/pull/299))
 
+### Removed
+
+- `stac::read_json` from the public API ([#301](https://github.com/stac-utils/stac-rs/pull/301))
+
 ## [0.8.0] - 2024-08-12
 
 ### Added

--- a/stac/src/io.rs
+++ b/stac/src/io.rs
@@ -17,14 +17,7 @@ pub fn read<T: Href + DeserializeOwned>(href: impl ToString) -> Result<T> {
     Ok(value)
 }
 
-/// Reads any deserializable value from the JSON at an href.
-///
-/// # Examples
-///
-/// ```
-/// let value: stac::Item = stac::read_json("data/simple-item.json").unwrap();
-/// ```
-pub fn read_json<T>(href: &str) -> Result<T>
+pub(crate) fn read_json<T>(href: &str) -> Result<T>
 where
     T: DeserializeOwned,
 {

--- a/stac/src/item.rs
+++ b/stac/src/item.rs
@@ -802,7 +802,7 @@ mod tests {
 
     #[test]
     fn deserialize_invalid_type_field() {
-        let mut item: Value = crate::read_json("data/simple-item.json").unwrap();
+        let mut item: Value = crate::io::read_json("data/simple-item.json").unwrap();
         item["type"] = "Item".into(); // must be "Feature"
         assert!(serde_json::from_value::<Item>(item).is_err());
     }

--- a/stac/src/lib.rs
+++ b/stac/src/lib.rs
@@ -151,7 +151,7 @@ pub use {
     extensions::{Extension, Extensions},
     fields::Fields,
     href::{href_to_url, Href},
-    io::{read, read_json},
+    io::read,
     item::{FlatItem, Item, Properties, ITEM_TYPE},
     item_collection::{ItemCollection, ITEM_COLLECTION_TYPE},
     link::{Link, Links},

--- a/stac/src/migrate.rs
+++ b/stac/src/migrate.rs
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(asset.bands[2].name.as_ref().unwrap(), "b");
         assert_eq!(asset.bands[3].name.as_ref().unwrap(), "nir");
 
-        let expected: Value = crate::read_json("examples/bands-v1.1.0-beta.1.json").unwrap();
+        let expected: Value = crate::io::read_json("examples/bands-v1.1.0-beta.1.json").unwrap();
         assert_json_eq!(expected, serde_json::to_value(item).unwrap());
 
         let collection = Collection::new("an-id", "a description");


### PR DESCRIPTION
It doesn't really belong in our lib's API.
