### PR TITLE
Don't include null assets when deseiralizing from arrow

### DIFF
--- a/scripts/requirements-stac-geoparquet.txt
+++ b/scripts/requirements-stac-geoparquet.txt
@@ -8,11 +8,11 @@ ciso8601==2.3.1
     # via stac-geoparquet
 deepdiff==7.0.1
     # via -r scripts/requirements-stac-geoparquet.in
-deltalake==0.18.2
+deltalake==0.19.1
     # via stac-geoparquet
 geopandas==1.0.1
     # via stac-geoparquet
-numpy==2.0.1
+numpy==2.1.0
     # via
     #   geopandas
     #   pandas
@@ -21,7 +21,7 @@ numpy==2.0.1
     #   shapely
 ordered-set==4.1.0
     # via deepdiff
-orjson==3.10.6
+orjson==3.10.7
     # via stac-geoparquet
 packaging==24.1
     # via
@@ -37,8 +37,6 @@ pyarrow==17.0.0
     #   -r scripts/requirements-stac-geoparquet.in
     #   deltalake
     #   stac-geoparquet
-pyarrow-hotfix==0.6
-    # via deltalake
 pyogrio==0.9.0
     # via geopandas
 pyproj==3.6.1
@@ -53,7 +51,7 @@ python-dateutil==2.9.0.post0
     #   pystac
 pytz==2024.1
     # via pandas
-shapely==2.0.5
+shapely==2.0.6
     # via
     #   geopandas
     #   stac-geoparquet

--- a/stac-arrow/examples/two-sentinel-2-items.json
+++ b/stac-arrow/examples/two-sentinel-2-items.json
@@ -1,0 +1,1488 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "id": "S2B_MSIL2A_20240825T173909_R098_T13TDE_20240825T215747",
+            "bbox": [
+                -105.3636533,
+                39.6593882,
+                -104.8845569,
+                40.6507988
+            ],
+            "type": "Feature",
+            "links": [
+                {
+                    "rel": "collection",
+                    "type": "application/json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a"
+                },
+                {
+                    "rel": "parent",
+                    "type": "application/json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a"
+                },
+                {
+                    "rel": "root",
+                    "type": "application/json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/"
+                },
+                {
+                    "rel": "self",
+                    "type": "application/geo+json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20240825T173909_R098_T13TDE_20240825T215747"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"
+                },
+                {
+                    "rel": "preview",
+                    "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/map?collection=sentinel-2-l2a&item=S2B_MSIL2A_20240825T173909_R098_T13TDE_20240825T215747",
+                    "title": "Map of item",
+                    "type": "text/html"
+                }
+            ],
+            "assets": {
+                "AOT": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R10m/T13TDE_20240825T173909_AOT_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Aerosol optical thickness (AOT)"
+                },
+                "B01": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R60m/T13TDE_20240825T173909_B01_60m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        1830,
+                        1830
+                    ],
+                    "proj:transform": [
+                        60.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -60.0,
+                        4500000.0
+                    ],
+                    "gsd": 60.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 1 - Coastal aerosol - 60m",
+                    "eo:bands": [
+                        {
+                            "name": "B01",
+                            "common_name": "coastal",
+                            "description": "Band 1 - Coastal aerosol",
+                            "center_wavelength": 0.443,
+                            "full_width_half_max": 0.027
+                        }
+                    ]
+                },
+                "B02": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R10m/T13TDE_20240825T173909_B02_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 2 - Blue - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "description": "Band 2 - Blue",
+                            "center_wavelength": 0.49,
+                            "full_width_half_max": 0.098
+                        }
+                    ]
+                },
+                "B03": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R10m/T13TDE_20240825T173909_B03_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 3 - Green - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "description": "Band 3 - Green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045
+                        }
+                    ]
+                },
+                "B04": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R10m/T13TDE_20240825T173909_B04_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 4 - Red - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "description": "Band 4 - Red",
+                            "center_wavelength": 0.665,
+                            "full_width_half_max": 0.038
+                        }
+                    ]
+                },
+                "B05": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R20m/T13TDE_20240825T173909_B05_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 5 - Vegetation red edge 1 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B05",
+                            "common_name": "rededge",
+                            "description": "Band 5 - Vegetation red edge 1",
+                            "center_wavelength": 0.704,
+                            "full_width_half_max": 0.019
+                        }
+                    ]
+                },
+                "B06": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R20m/T13TDE_20240825T173909_B06_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 6 - Vegetation red edge 2 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B06",
+                            "common_name": "rededge",
+                            "description": "Band 6 - Vegetation red edge 2",
+                            "center_wavelength": 0.74,
+                            "full_width_half_max": 0.018
+                        }
+                    ]
+                },
+                "B07": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R20m/T13TDE_20240825T173909_B07_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 7 - Vegetation red edge 3 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B07",
+                            "common_name": "rededge",
+                            "description": "Band 7 - Vegetation red edge 3",
+                            "center_wavelength": 0.783,
+                            "full_width_half_max": 0.028
+                        }
+                    ]
+                },
+                "B08": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R10m/T13TDE_20240825T173909_B08_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 8 - NIR - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B08",
+                            "common_name": "nir",
+                            "description": "Band 8 - NIR",
+                            "center_wavelength": 0.842,
+                            "full_width_half_max": 0.145
+                        }
+                    ]
+                },
+                "B09": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R60m/T13TDE_20240825T173909_B09_60m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        1830,
+                        1830
+                    ],
+                    "proj:transform": [
+                        60.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -60.0,
+                        4500000.0
+                    ],
+                    "gsd": 60.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 9 - Water vapor - 60m",
+                    "eo:bands": [
+                        {
+                            "name": "B09",
+                            "description": "Band 9 - Water vapor",
+                            "center_wavelength": 0.945,
+                            "full_width_half_max": 0.026
+                        }
+                    ]
+                },
+                "B11": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R20m/T13TDE_20240825T173909_B11_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 11 - SWIR (1.6) - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B11",
+                            "common_name": "swir16",
+                            "description": "Band 11 - SWIR (1.6)",
+                            "center_wavelength": 1.61,
+                            "full_width_half_max": 0.143
+                        }
+                    ]
+                },
+                "B12": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R20m/T13TDE_20240825T173909_B12_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 12 - SWIR (2.2) - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B12",
+                            "common_name": "swir22",
+                            "description": "Band 12 - SWIR (2.2)",
+                            "center_wavelength": 2.19,
+                            "full_width_half_max": 0.242
+                        }
+                    ]
+                },
+                "B8A": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R20m/T13TDE_20240825T173909_B8A_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 8A - Vegetation red edge 4 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B8A",
+                            "common_name": "rededge",
+                            "description": "Band 8A - Vegetation red edge 4",
+                            "center_wavelength": 0.865,
+                            "full_width_half_max": 0.033
+                        }
+                    ]
+                },
+                "SCL": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R20m/T13TDE_20240825T173909_SCL_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Scene classfication map (SCL)"
+                },
+                "WVP": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R10m/T13TDE_20240825T173909_WVP_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Water vapour (WVP)"
+                },
+                "visual": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/IMG_DATA/R10m/T13TDE_20240825T173909_TCI_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "description": "Band 4 - Red",
+                            "center_wavelength": 0.665,
+                            "full_width_half_max": 0.038
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "description": "Band 3 - Green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "description": "Band 2 - Blue",
+                            "center_wavelength": 0.49,
+                            "full_width_half_max": 0.098
+                        }
+                    ]
+                },
+                "safe-manifest": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/manifest.safe",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "SAFE manifest"
+                },
+                "granule-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/GRANULE/L2A_T13TDE_A039020_20240825T174804/MTD_TL.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "Granule metadata"
+                },
+                "inspire-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/INSPIRE.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "INSPIRE metadata"
+                },
+                "product-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/MTD_MSIL2A.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "Product metadata"
+                },
+                "datastrip-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/25/S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE/DATASTRIP/DS_2BPS_20240825T215747_S20240825T174804/MTD_DS.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "Datastrip metadata"
+                },
+                "tilejson": {
+                    "title": "TileJSON with default rendering",
+                    "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/tilejson.json?collection=sentinel-2-l2a&item=S2B_MSIL2A_20240825T173909_R098_T13TDE_20240825T215747&assets=visual&asset_bidx=visual%7C1%2C2%2C3&nodata=0&format=png",
+                    "type": "application/json",
+                    "roles": [
+                        "tiles"
+                    ]
+                },
+                "rendered_preview": {
+                    "title": "Rendered preview",
+                    "rel": "preview",
+                    "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/preview.png?collection=sentinel-2-l2a&item=S2B_MSIL2A_20240825T173909_R098_T13TDE_20240825T215747&assets=visual&asset_bidx=visual%7C1%2C2%2C3&nodata=0&format=png",
+                    "roles": [
+                        "overview"
+                    ],
+                    "type": "image/png"
+                }
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -105.3636533,
+                            39.6593882
+                        ],
+                        [
+                            -105.3194891,
+                            39.8060109
+                        ],
+                        [
+                            -105.2765332,
+                            39.9536675
+                        ],
+                        [
+                            -105.2327063,
+                            40.1011169
+                        ],
+                        [
+                            -105.1880901,
+                            40.2483738
+                        ],
+                        [
+                            -105.1436644,
+                            40.3956704
+                        ],
+                        [
+                            -105.0990149,
+                            40.5428492
+                        ],
+                        [
+                            -105.0663671,
+                            40.6499582
+                        ],
+                        [
+                            -104.8845569,
+                            40.6507988
+                        ],
+                        [
+                            -104.8862201,
+                            39.6615512
+                        ],
+                        [
+                            -105.3636533,
+                            39.6593882
+                        ]
+                    ]
+                ]
+            },
+            "collection": "sentinel-2-l2a",
+            "properties": {
+                "datetime": "2024-08-25T17:39:09.024000Z",
+                "platform": "Sentinel-2B",
+                "proj:epsg": 32613,
+                "instruments": [
+                    "msi"
+                ],
+                "s2:mgrs_tile": "13TDE",
+                "constellation": "Sentinel 2",
+                "s2:granule_id": "S2B_OPER_MSI_L2A_TL_2BPS_20240825T215747_A039020_T13TDE_N05.11",
+                "eo:cloud_cover": 48.747352,
+                "s2:datatake_id": "GS2B_20240825T173909_039020_N05.11",
+                "s2:product_uri": "S2B_MSIL2A_20240825T173909_N0511_R098_T13TDE_20240825T215747.SAFE",
+                "s2:datastrip_id": "S2B_OPER_MSI_L2A_DS_2BPS_20240825T215747_S20240825T174804_N05.11",
+                "s2:product_type": "S2MSI2A",
+                "sat:orbit_state": "descending",
+                "s2:datatake_type": "INS-NOBS",
+                "s2:generation_time": "2024-08-25T21:57:47.000000Z",
+                "sat:relative_orbit": 98,
+                "s2:water_percentage": 1.627593,
+                "s2:mean_solar_zenith": 33.6615274396343,
+                "s2:mean_solar_azimuth": 147.243556565213,
+                "s2:processing_baseline": "05.11",
+                "s2:snow_ice_percentage": 0.0,
+                "s2:vegetation_percentage": 11.635023,
+                "s2:thin_cirrus_percentage": 1.487926,
+                "s2:cloud_shadow_percentage": 0.598632,
+                "s2:nodata_pixel_percentage": 74.752849,
+                "s2:unclassified_percentage": 5.732427,
+                "s2:not_vegetated_percentage": 31.641838,
+                "s2:degraded_msi_data_percentage": 0.0,
+                "s2:high_proba_clouds_percentage": 19.551201,
+                "s2:reflectance_conversion_factor": 0.977803669193003,
+                "s2:medium_proba_clouds_percentage": 27.708223,
+                "s2:saturated_defective_pixel_percentage": 0.0
+            },
+            "stac_extensions": [
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+            ],
+            "stac_version": "1.0.0"
+        },
+        {
+            "id": "S2A_MSIL2A_20240823T174901_R141_T13TDE_20240824T013055",
+            "bbox": [
+                -106.1831726,
+                39.6557526,
+                -104.8845569,
+                40.6507988
+            ],
+            "type": "Feature",
+            "links": [
+                {
+                    "rel": "collection",
+                    "type": "application/json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a"
+                },
+                {
+                    "rel": "parent",
+                    "type": "application/json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a"
+                },
+                {
+                    "rel": "root",
+                    "type": "application/json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/"
+                },
+                {
+                    "rel": "self",
+                    "type": "application/geo+json",
+                    "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2A_MSIL2A_20240823T174901_R141_T13TDE_20240824T013055"
+                },
+                {
+                    "rel": "license",
+                    "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"
+                },
+                {
+                    "rel": "preview",
+                    "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/map?collection=sentinel-2-l2a&item=S2A_MSIL2A_20240823T174901_R141_T13TDE_20240824T013055",
+                    "title": "Map of item",
+                    "type": "text/html"
+                }
+            ],
+            "assets": {
+                "AOT": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R10m/T13TDE_20240823T174901_AOT_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Aerosol optical thickness (AOT)"
+                },
+                "B01": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R60m/T13TDE_20240823T174901_B01_60m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        1830,
+                        1830
+                    ],
+                    "proj:transform": [
+                        60.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -60.0,
+                        4500000.0
+                    ],
+                    "gsd": 60.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 1 - Coastal aerosol - 60m",
+                    "eo:bands": [
+                        {
+                            "name": "B01",
+                            "common_name": "coastal",
+                            "description": "Band 1 - Coastal aerosol",
+                            "center_wavelength": 0.443,
+                            "full_width_half_max": 0.027
+                        }
+                    ]
+                },
+                "B02": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R10m/T13TDE_20240823T174901_B02_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 2 - Blue - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "description": "Band 2 - Blue",
+                            "center_wavelength": 0.49,
+                            "full_width_half_max": 0.098
+                        }
+                    ]
+                },
+                "B03": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R10m/T13TDE_20240823T174901_B03_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 3 - Green - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "description": "Band 3 - Green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045
+                        }
+                    ]
+                },
+                "B04": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R10m/T13TDE_20240823T174901_B04_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 4 - Red - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "description": "Band 4 - Red",
+                            "center_wavelength": 0.665,
+                            "full_width_half_max": 0.038
+                        }
+                    ]
+                },
+                "B05": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R20m/T13TDE_20240823T174901_B05_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 5 - Vegetation red edge 1 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B05",
+                            "common_name": "rededge",
+                            "description": "Band 5 - Vegetation red edge 1",
+                            "center_wavelength": 0.704,
+                            "full_width_half_max": 0.019
+                        }
+                    ]
+                },
+                "B06": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R20m/T13TDE_20240823T174901_B06_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 6 - Vegetation red edge 2 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B06",
+                            "common_name": "rededge",
+                            "description": "Band 6 - Vegetation red edge 2",
+                            "center_wavelength": 0.74,
+                            "full_width_half_max": 0.018
+                        }
+                    ]
+                },
+                "B07": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R20m/T13TDE_20240823T174901_B07_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 7 - Vegetation red edge 3 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B07",
+                            "common_name": "rededge",
+                            "description": "Band 7 - Vegetation red edge 3",
+                            "center_wavelength": 0.783,
+                            "full_width_half_max": 0.028
+                        }
+                    ]
+                },
+                "B08": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R10m/T13TDE_20240823T174901_B08_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 8 - NIR - 10m",
+                    "eo:bands": [
+                        {
+                            "name": "B08",
+                            "common_name": "nir",
+                            "description": "Band 8 - NIR",
+                            "center_wavelength": 0.842,
+                            "full_width_half_max": 0.145
+                        }
+                    ]
+                },
+                "B09": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R60m/T13TDE_20240823T174901_B09_60m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        1830,
+                        1830
+                    ],
+                    "proj:transform": [
+                        60.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -60.0,
+                        4500000.0
+                    ],
+                    "gsd": 60.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 9 - Water vapor - 60m",
+                    "eo:bands": [
+                        {
+                            "name": "B09",
+                            "description": "Band 9 - Water vapor",
+                            "center_wavelength": 0.945,
+                            "full_width_half_max": 0.026
+                        }
+                    ]
+                },
+                "B11": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R20m/T13TDE_20240823T174901_B11_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 11 - SWIR (1.6) - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B11",
+                            "common_name": "swir16",
+                            "description": "Band 11 - SWIR (1.6)",
+                            "center_wavelength": 1.61,
+                            "full_width_half_max": 0.143
+                        }
+                    ]
+                },
+                "B12": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R20m/T13TDE_20240823T174901_B12_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 12 - SWIR (2.2) - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B12",
+                            "common_name": "swir22",
+                            "description": "Band 12 - SWIR (2.2)",
+                            "center_wavelength": 2.19,
+                            "full_width_half_max": 0.242
+                        }
+                    ]
+                },
+                "B8A": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R20m/T13TDE_20240823T174901_B8A_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Band 8A - Vegetation red edge 4 - 20m",
+                    "eo:bands": [
+                        {
+                            "name": "B8A",
+                            "common_name": "rededge",
+                            "description": "Band 8A - Vegetation red edge 4",
+                            "center_wavelength": 0.865,
+                            "full_width_half_max": 0.033
+                        }
+                    ]
+                },
+                "SCL": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R20m/T13TDE_20240823T174901_SCL_20m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        5490,
+                        5490
+                    ],
+                    "proj:transform": [
+                        20.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -20.0,
+                        4500000.0
+                    ],
+                    "gsd": 20.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Scene classfication map (SCL)"
+                },
+                "WVP": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R10m/T13TDE_20240823T174901_WVP_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "Water vapour (WVP)"
+                },
+                "visual": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/IMG_DATA/R10m/T13TDE_20240823T174901_TCI_10m.tif",
+                    "proj:bbox": [
+                        399960.0,
+                        4390200.0,
+                        509760.0,
+                        4500000.0
+                    ],
+                    "proj:shape": [
+                        10980,
+                        10980
+                    ],
+                    "proj:transform": [
+                        10.0,
+                        0.0,
+                        399960.0,
+                        0.0,
+                        -10.0,
+                        4500000.0
+                    ],
+                    "gsd": 10.0,
+                    "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                    "roles": [
+                        "data"
+                    ],
+                    "title": "True color image",
+                    "eo:bands": [
+                        {
+                            "name": "B04",
+                            "common_name": "red",
+                            "description": "Band 4 - Red",
+                            "center_wavelength": 0.665,
+                            "full_width_half_max": 0.038
+                        },
+                        {
+                            "name": "B03",
+                            "common_name": "green",
+                            "description": "Band 3 - Green",
+                            "center_wavelength": 0.56,
+                            "full_width_half_max": 0.045
+                        },
+                        {
+                            "name": "B02",
+                            "common_name": "blue",
+                            "description": "Band 2 - Blue",
+                            "center_wavelength": 0.49,
+                            "full_width_half_max": 0.098
+                        }
+                    ]
+                },
+                "safe-manifest": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/manifest.safe",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "SAFE manifest"
+                },
+                "granule-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/GRANULE/L2A_T13TDE_A047900_20240823T175543/MTD_TL.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "Granule metadata"
+                },
+                "inspire-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/INSPIRE.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "INSPIRE metadata"
+                },
+                "product-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/MTD_MSIL2A.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "Product metadata"
+                },
+                "datastrip-metadata": {
+                    "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/13/T/DE/2024/08/23/S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE/DATASTRIP/DS_2APS_20240824T013055_S20240823T175543/MTD_DS.xml",
+                    "type": "application/xml",
+                    "roles": [
+                        "metadata"
+                    ],
+                    "title": "Datastrip metadata"
+                },
+                "tilejson": {
+                    "title": "TileJSON with default rendering",
+                    "href": "https://planetarycomputer.microsoft.com/api/data/v1/item/tilejson.json?collection=sentinel-2-l2a&item=S2A_MSIL2A_20240823T174901_R141_T13TDE_20240824T013055&assets=visual&asset_bidx=visual%7C1%2C2%2C3&nodata=0&format=png",
+                    "type": "application/json",
+                    "roles": [
+                        "tiles"
+                    ]
+                }
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [
+                            -106.1831726,
+                            40.6447948
+                        ],
+                        [
+                            -104.8845569,
+                            40.6507988
+                        ],
+                        [
+                            -104.8862201,
+                            39.6615512
+                        ],
+                        [
+                            -106.1661317,
+                            39.6557526
+                        ],
+                        [
+                            -106.1831726,
+                            40.6447948
+                        ]
+                    ]
+                ]
+            },
+            "collection": "sentinel-2-l2a",
+            "properties": {
+                "datetime": "2024-08-23T17:49:01.024000Z",
+                "platform": "Sentinel-2A",
+                "proj:epsg": 32613,
+                "instruments": [
+                    "msi"
+                ],
+                "s2:mgrs_tile": "13TDE",
+                "constellation": "Sentinel 2",
+                "s2:granule_id": "S2A_OPER_MSI_L2A_TL_2APS_20240824T013055_A047900_T13TDE_N05.11",
+                "eo:cloud_cover": 66.843867,
+                "s2:datatake_id": "GS2A_20240823T174901_047900_N05.11",
+                "s2:product_uri": "S2A_MSIL2A_20240823T174901_N0511_R141_T13TDE_20240824T013055.SAFE",
+                "s2:datastrip_id": "S2A_OPER_MSI_L2A_DS_2APS_20240824T013055_S20240823T175543_N05.11",
+                "s2:product_type": "S2MSI2A",
+                "sat:orbit_state": "descending",
+                "s2:datatake_type": "INS-NOBS",
+                "s2:generation_time": "2024-08-24T01:30:55.000000Z",
+                "sat:relative_orbit": 141,
+                "s2:water_percentage": 0.699692,
+                "s2:mean_solar_zenith": 32.1087599655615,
+                "s2:mean_solar_azimuth": 150.613954587322,
+                "s2:processing_baseline": "05.11",
+                "s2:snow_ice_percentage": 0.028779,
+                "s2:vegetation_percentage": 8.731826,
+                "s2:thin_cirrus_percentage": 0.145696,
+                "s2:cloud_shadow_percentage": 1.653979,
+                "s2:nodata_pixel_percentage": 0.0,
+                "s2:unclassified_percentage": 2.464116,
+                "s2:not_vegetated_percentage": 19.438161,
+                "s2:degraded_msi_data_percentage": 0.1844,
+                "s2:high_proba_clouds_percentage": 37.35922,
+                "s2:reflectance_conversion_factor": 0.976998451581717,
+                "s2:medium_proba_clouds_percentage": 29.33895,
+                "s2:saturated_defective_pixel_percentage": 0.0
+            },
+            "stac_extensions": [
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+            ],
+            "stac_version": "1.0.0"
+        }
+    ],
+    "links": [],
+    "numberReturned": 2
+}

--- a/stac-arrow/src/json.rs
+++ b/stac-arrow/src/json.rs
@@ -435,7 +435,13 @@ fn record_batches_to_json_rows_internal(
         }
     }
 
-    Ok(rows.into_iter().map(|a| a.unwrap()))
+    Ok(rows.into_iter().map(|a| {
+        let mut a = a.unwrap();
+        if let Some(assets) = a.get_mut("assets").and_then(|a| a.as_object_mut()) {
+            assets.retain(|_, asset| asset.is_object());
+        }
+        a
+    }))
 }
 
 fn convert_bbox(obj: serde_json::Map<String, Value>) -> Value {

--- a/stac-arrow/src/lib.rs
+++ b/stac-arrow/src/lib.rs
@@ -302,6 +302,7 @@ pub fn from_table(table: Table) -> Result<ItemCollection> {
 #[cfg(test)]
 mod tests {
     use geoarrow::io::parquet::GeoParquetRecordBatchReaderBuilder;
+    use stac::ItemCollection;
     use stac_validate::Validate;
     use std::fs::File;
 
@@ -328,6 +329,13 @@ mod tests {
     fn roundtrip() {
         let item = stac::read("data/simple-item.json").unwrap();
         let table = super::to_table(vec![item].into()).unwrap();
+        let _ = super::from_table(table).unwrap();
+    }
+
+    #[test]
+    fn roundtrip_with_missing_asset() {
+        let items: ItemCollection = stac::read("examples/two-sentinel-2-items.json").unwrap();
+        let table = super::to_table(items).unwrap();
         let _ = super::from_table(table).unwrap();
     }
 }


### PR DESCRIPTION
## Related to

- This issue describes what's going on: https://github.com/stac-utils/stac-geoparquet/issues/77

## Checklist

- [x] Unit tests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
