### PR TITLE
Pin to v1.0

### DIFF
--- a/duckdb/Cargo.toml
+++ b/duckdb/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science", "data-structures"]
 
 [dependencies]
 arrow = "52"
-duckdb = "1"
+duckdb = "1.0"
 geoarrow = { version = "0.3" }
 parquet = "52"
 stac = { version = "0.9.0", path = "../core", features = ["geoarrow"] }


### PR DESCRIPTION
## Related to

- More information on geoparquet support here: https://github.com/duckdb/duckdb_spatial/issues/27

## Description

v1.1, though it supposedly has geoparquet support, breaks things. Pin this for now.
