### PR TITLE
Async validation

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Conversion traits for the three formats ([#396](https://github.com/stac-utils/stac-rs/pull/396))
 - `object_store` ([#382](https://github.com/stac-utils/stac-rs/pull/382))
 - `stac::geoparquet::Compression`, even if geoparquet is not enabled ([#396](https://github.com/stac-utils/stac-rs/pull/396))
+- `Type` ([#397](https://github.com/stac-utils/stac-rs/pull/397))
 
 ### Changed
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -23,5 +23,5 @@ serde = "1"
 serde_json = "1"
 stac = { path = "../core", features = ["reqwest", "object-store-all"] }
 stac-api = { path = "../api", features = ["client"] }
-stac-validate = { path = "../validate" }
+stac-validate = { path = "../validate", features = ["blocking"] }
 tokio = { version = "1", features = ["rt"] }

--- a/python/src/validate.rs
+++ b/python/src/validate.rs
@@ -1,7 +1,7 @@
 use crate::{Error, Result};
 use pyo3::{prelude::*, types::PyDict};
 use stac::Value;
-use stac_validate::Validate;
+use stac_validate::ValidateBlocking;
 
 /// Validates a single href with json-schema.
 ///
@@ -42,7 +42,7 @@ pub fn validate(value: &Bound<'_, PyDict>) -> PyResult<()> {
 }
 
 fn validate_value(value: Value) -> Result<()> {
-    if let Err(error) = value.validate() {
+    if let Err(error) = value.validate_blocking() {
         match error {
             stac_validate::Error::Validation(errors) => {
                 let mut message = "Validation errors: ".to_string();

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -418,7 +418,7 @@ mod tests {
         let root = api.root().await.unwrap();
         assert!(!root.conformance.conforms_to.is_empty());
         let catalog: Catalog = serde_json::from_value(serde_json::to_value(root).unwrap()).unwrap();
-        catalog.validate().unwrap();
+        catalog.validate().await.unwrap();
         assert_eq!(catalog.id, "an-id");
         assert_eq!(catalog.description, "a description");
         assert_link!(
@@ -511,7 +511,7 @@ mod tests {
         );
         assert_eq!(collections.collections.len(), 1);
         let collection = &collections.collections[0];
-        collection.validate().unwrap();
+        collection.validate().await.unwrap();
         assert_link!(
             collection.link("root"),
             "http://stac.test/",
@@ -543,7 +543,7 @@ mod tests {
             .unwrap();
         let api = test_api(backend);
         let collection = api.collection("a-collection").await.unwrap().unwrap();
-        collection.validate().unwrap();
+        collection.validate().await.unwrap();
         assert_link!(
             collection.link("root"),
             "http://stac.test/",

--- a/validate/CHANGELOG.md
+++ b/validate/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## Changed
+
+- Moved to async-first, with a blocking interface ([#397](https://github.com/stac-utils/stac-rs/pull/397))
+
 ## [0.2.2] - 2024-09-06
 
 ### Added

--- a/validate/Cargo.toml
+++ b/validate/Cargo.toml
@@ -10,17 +10,31 @@ license = "MIT OR Apache-2.0"
 keywords = ["geospatial", "stac", "metadata", "geo", "raster"]
 categories = ["science", "data-structures"]
 
+[features]
+blocking = ["tokio/rt"]
+
 [dependencies]
 jsonschema = "0.19"
-log = "0.4"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = "1"
 serde_json = "1"
 stac = { version = "0.9.0", path = "../core" }
 thiserror = "1"
+tokio = "1"
+tracing = "0.1"
 url = "2"
 
 [dev-dependencies]
 geojson = "0.24"
 stac = { version = "0.9.0", path = "../core", features = ["geo"] }
 rstest = "0.22"
+tokio = { version = "1", features = ["macros"] }
+tokio-test = "0.4"
+
+[[test]]
+name = "examples"
+required-features = ["blocking"]
+
+[[test]]
+name = "migrate"
+required-features = ["blocking"]

--- a/validate/README.md
+++ b/validate/README.md
@@ -6,7 +6,7 @@
 ![Crates.io](https://img.shields.io/crates/l/stac-validate?style=for-the-badge)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](./CODE_OF_CONDUCT)
 
-Validate [STAC](https://stacspec.org/) with [jsonschema](https://json-schema.org/).
+Validate [STAC](https://stacspec.org/) with [json-schema](https://json-schema.org/).
 
 ## Usage
 
@@ -22,7 +22,9 @@ stac-validate = "0.2"
 ```rust
 use stac_validate::Validate;
 let item: stac::Item = stac::read("examples/simple-item.json").unwrap();
-item.validate().unwrap();
+tokio_test::block_on(async {
+    item.validate().await.unwrap();
+});
 ```
 
 Please see the [documentation](https://docs.rs/stac-validate) for more usage examples.

--- a/validate/src/blocking.rs
+++ b/validate/src/blocking.rs
@@ -1,0 +1,82 @@
+use crate::{Result, Validate};
+use serde::Serialize;
+use tokio::runtime::Builder;
+
+/// Validate any serializable object with [json-schema](https://json-schema.org/)
+///
+/// This is a blocking alternative to [Validate]
+pub trait ValidateBlocking: Validate {
+    /// Validates this object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use stac_validate::ValidateBlocking;
+    /// use stac::Item;
+    ///
+    /// let mut item = Item::new("an-id");
+    /// item.validate_blocking().unwrap();
+    /// ```
+    fn validate_blocking(&self) -> Result<()> {
+        Builder::new_current_thread()
+            .enable_io()
+            .build()?
+            .block_on(self.validate())
+    }
+}
+
+impl<T: Serialize> ValidateBlocking for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::ValidateBlocking;
+    use geojson::{Geometry, Value};
+    use rstest as _;
+    use stac::{Catalog, Collection, Item};
+
+    #[test]
+    fn item() {
+        let item = Item::new("an-id");
+        item.validate_blocking().unwrap();
+    }
+
+    #[test]
+    fn item_with_geometry() {
+        let mut item = Item::new("an-id");
+        item.set_geometry(Geometry::new(Value::Point(vec![-105.1, 40.1])))
+            .unwrap();
+        item.validate_blocking().unwrap();
+    }
+
+    #[test]
+    fn item_with_extensions() {
+        let item: Item =
+            stac::read("examples/extensions-collection/proj-example/proj-example.json").unwrap();
+        item.validate_blocking().unwrap();
+    }
+
+    #[test]
+    fn catalog() {
+        let catalog = Catalog::new("an-id", "a description");
+        catalog.validate_blocking().unwrap();
+    }
+
+    #[test]
+    fn collection() {
+        let collection = Collection::new("an-id", "a description");
+        collection.validate_blocking().unwrap();
+    }
+
+    #[test]
+    fn value() {
+        let value: stac::Value = stac::read("examples/simple-item.json").unwrap();
+        value.validate_blocking().unwrap();
+    }
+
+    #[test]
+    fn item_collection() {
+        let item = stac::read("examples/simple-item.json").unwrap();
+        let item_collection = stac::ItemCollection::from(vec![item]);
+        item_collection.validate_blocking().unwrap();
+    }
+}

--- a/validate/src/validate.rs
+++ b/validate/src/validate.rs
@@ -1,153 +1,35 @@
-use crate::{Error, Result, Validator};
+use crate::{Result, Validator};
 use serde::Serialize;
-use serde_json::Value;
-use stac::{Catalog, Collection, Item, ItemCollection};
+use std::future::Future;
 
-/// Trait for validating STAC objects using [jsonschema].
-pub trait Validate: ValidateCore {
-    /// Validate this STAC object using [jsonschema].
+/// Validate any serializable object with [json-schema](https://json-schema.org/)
+pub trait Validate: Serialize + Sized {
+    /// Validates this object.
     ///
-    /// #  Examples
+    /// If the object fails validation, this will return an
+    /// [Error::Validation](crate::Error::Validation) which contains a vector of
+    /// all of the validation errors.
     ///
-    /// [stac::Item] implements [Validate]:
+    /// If you're doing multiple validations, use [Validator::validate], which
+    /// will re-use cached schemas.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use stac_validate::Validate;
-    /// let item = stac::Item::new("an-id");
-    /// item.validate().unwrap();
-    /// ```
-    fn validate(&self) -> Result<()> {
-        let mut validator = Validator::new();
-        self.validate_with_validator(&mut validator)
-    }
-
-    /// Validates a STAC object with the provided validator.
-    ///
-    /// #  Examples
-    ///
-    /// [stac::Item] implements [Validate]:
-    ///
-    /// ```
-    /// use stac_validate::{Validate, Validator};
-    ///
-    /// let mut validator = Validator::new();
-    /// let item = stac::Item::new("an-id");
-    /// item.validate_with_validator(&mut validator).unwrap();
-    /// ```
-    fn validate_with_validator(&self, validator: &mut Validator) -> Result<()> {
-        let value = serde_json::to_value(self)?;
-        let mut errors = match Self::validate_core_json(&value, validator) {
-            Ok(()) => Vec::new(),
-            Err(Error::Validation(errors)) => errors,
-            Err(err) => return Err(err),
-        };
-        match validator.validate_extensions(&value) {
-            Ok(()) => {}
-            Err(Error::Validation(extension_errors)) => errors.extend(extension_errors),
-            Err(err) => return Err(err),
-        }
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(Error::Validation(errors))
-        }
-    }
-}
-
-/// Trait for validating STAC objects against their core schema only.
-///
-/// If your STAC object is the same version as [stac::STAC_VERSION], this will
-/// be a quick, cheap operation, since the schemas are stored in the library.
-pub trait ValidateCore: Serialize {
-    /// Validate a [serde_json::Value] against a specific STAC jsonschema.
-    ///
-    /// #  Examples
-    ///
-    /// [stac::Item] implements [ValidateCore]:
-    ///
-    /// ```
-    /// use stac_validate::ValidateCore;
     /// use stac::Item;
     ///
-    /// let item = Item::new("an-id");
-    /// let value = serde_json::to_value(item).unwrap();
-    /// Item::validate_core_json(&value, &mut stac_validate::Validator::new()).unwrap();
+    /// let mut item = Item::new("an-id");
+    /// # tokio_test::block_on(async {
+    /// item.validate().await.unwrap();
+    /// });
     /// ```
-    fn validate_core_json(value: &Value, validator: &mut Validator) -> Result<()>;
-}
-
-impl Validate for Item {}
-
-impl ValidateCore for Item {
-    fn validate_core_json(value: &Value, validator: &mut Validator) -> Result<()> {
-        validator.validate_item(value)
-    }
-}
-
-impl Validate for Catalog {}
-
-impl ValidateCore for Catalog {
-    fn validate_core_json(value: &Value, validator: &mut Validator) -> Result<()> {
-        validator.validate_catalog(value)
-    }
-}
-
-impl Validate for Collection {}
-
-impl ValidateCore for Collection {
-    fn validate_core_json(value: &Value, validator: &mut Validator) -> Result<()> {
-        validator.validate_collection(value)
-    }
-}
-
-impl Validate for stac::Value {}
-
-impl ValidateCore for stac::Value {
-    fn validate_core_json(value: &Value, validator: &mut Validator) -> Result<()> {
-        if let Some(type_) = value.get("type") {
-            if let Some(type_) = type_.as_str() {
-                match type_ {
-                    "Feature" => validator.validate_item(value),
-                    "Collection" => validator.validate_collection(value),
-                    "Catalog" => validator.validate_catalog(value),
-                    "FeatureCollection" => validator.validate_item_collection(value),
-                    _ => Err(stac::Error::UnknownType(type_.to_string()).into()),
-                }
-            } else {
-                Err(stac::Error::InvalidTypeField(type_.clone()).into())
-            }
-        } else {
-            Err(stac::Error::MissingType.into())
+    fn validate(&self) -> impl Future<Output = Result<()>> {
+        async {
+            let validator = Validator::new().await;
+            validator.validate(self).await
         }
     }
 }
 
-impl Validate for ItemCollection {}
-
-impl ValidateCore for ItemCollection {
-    fn validate_core_json(value: &Value, validator: &mut Validator) -> Result<()> {
-        validator.validate_item_collection(value)
-    }
-}
-
-impl Validate for Value {}
-
-impl ValidateCore for Value {
-    fn validate_core_json(value: &Value, validator: &mut Validator) -> Result<()> {
-        if let Some(type_) = value.get("type") {
-            if let Some(type_) = type_.as_str() {
-                match type_ {
-                    "Feature" => validator.validate_item(value),
-                    "Collection" => validator.validate_collection(value),
-                    "Catalog" => validator.validate_catalog(value),
-                    "FeatureCollection" => validator.validate_item_collection(value),
-                    _ => Err(stac::Error::UnknownType(type_.to_string()).into()),
-                }
-            } else {
-                Err(stac::Error::InvalidTypeField(type_.clone()).into())
-            }
-        } else {
-            Err(stac::Error::MissingType.into())
-        }
-    }
-}
+impl<T: Serialize> Validate for T {}

--- a/validate/tests/examples.rs
+++ b/validate/tests/examples.rs
@@ -1,16 +1,16 @@
 use rstest::rstest;
 use stac::Value;
-use stac_validate::Validate;
+use stac_validate::ValidateBlocking;
 use std::path::PathBuf;
 
 #[rstest]
 fn v1_0_0(#[files("../spec-examples/v1.0.0/**/*.json")] path: PathBuf) {
     let value: Value = stac::read(path.to_str().unwrap()).unwrap();
-    value.validate().unwrap();
+    value.validate_blocking().unwrap();
 }
 
 #[rstest]
 fn v1_1_0_beta_1(#[files("../spec-examples/v1.1.0-beta.1/**/*.json")] path: PathBuf) {
     let value: Value = stac::read(path.to_str().unwrap()).unwrap();
-    value.validate().unwrap();
+    value.validate_blocking().unwrap();
 }

--- a/validate/tests/migrate.rs
+++ b/validate/tests/migrate.rs
@@ -1,11 +1,11 @@
 use rstest::rstest;
 use stac::{Migrate, Value, Version};
-use stac_validate::Validate;
+use stac_validate::ValidateBlocking;
 use std::path::PathBuf;
 
 #[rstest]
 fn v1_0_0_to_v1_1_0_beta_1(#[files("../spec-examples/v1.0.0/**/*.json")] path: PathBuf) {
     let value: Value = stac::read(path.to_str().unwrap()).unwrap();
     let value = value.migrate(&Version::v1_1_0_beta_1).unwrap();
-    value.validate().unwrap();
+    value.validate_blocking().unwrap();
 }


### PR DESCRIPTION
- Closes #207

This popped up as a need while working on #376 — when I updated the default version to v1.1.0, some server tests broke because they were validating within a tokio runtime.