### PR TITLE
Import python implementations from python, not rust wrapper

### DIFF
--- a/python/python/stacrs/__init__.py
+++ b/python/python/stacrs/__init__.py
@@ -1,16 +1,19 @@
-from . import stacrs
-from .stacrs import (
+import pystac
+from .pystac import (
     migrate,
-    migrate_href,
     read,
     search,
-    search_to,
     validate,
-    validate_href,
     write,
 )
 
-__doc__ = stacrs.__doc__
+from .stacrs import (
+    migrate_href,
+    search_to,
+    validate_href,
+)
+
+__doc__ = pystac.__doc__
 __all__ = [
     "migrate",
     "migrate_href",

--- a/python/python/stacrs/pystac.py
+++ b/python/python/stacrs/pystac.py
@@ -149,7 +149,7 @@ def search(
         ...     max_items=1,
         ... ))
     """
-    items = stacrs.search(
+    items_dict = stacrs.search(
         href,
         intersects=intersects,
         ids=ids,
@@ -164,7 +164,7 @@ def search(
         filter=filter,
         query=query,
     )
-    return (Item.from_dict(d) for d in items)
+    return ItemCollection(Item.from_dict(d) for d in items_dict)
 
 
 def validate(


### PR DESCRIPTION
## Closes

- Closes https://github.com/stac-utils/stac-rs/issues/462

## Related to

## Description

Fixes the main import for the __init__.py file by importing the Python implementations rather than the naked rust wrappers of them.

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [ ] Unit tests
- [ ] Documentation, including doctests
- [ ] Git history is linear
- [ ] Commit messages are descriptive
- [ ] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Code is formatted (`cargo fmt`)
- [ ] `cargo test`
- [ ] Changes are added to the CHANGELOG
