### PR TITLE
chore: Replace Fields impl for Item with derive.

### DIFF
--- a/crates/core/src/item.rs
+++ b/crates/core/src/item.rs
@@ -1,11 +1,11 @@
 //! STAC Items.
 
-use crate::{Asset, Assets, Bbox, Error, Fields, Href, Link, Result, Version, STAC_VERSION};
+use crate::{Asset, Assets, Bbox, Error, Href, Link, Result, Version, STAC_VERSION};
 use chrono::{DateTime, FixedOffset, Utc};
 use geojson::{feature::Id, Feature, Geometry};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use stac_derive::{Links, Migrate, SelfHref};
+use stac_derive::{Fields, Links, Migrate, SelfHref};
 use std::{collections::HashMap, path::Path};
 use url::Url;
 
@@ -27,7 +27,7 @@ const TOP_LEVEL_ATTRIBUTES: [&str; 8] = [
 /// `Item` is the core object in a STAC catalog, containing the core metadata that
 /// enables any client to search or crawl online catalogs of spatial 'assets'
 /// (e.g., satellite imagery, derived data, DEMs).
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, SelfHref, Links, Migrate)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, SelfHref, Links, Migrate, Fields)]
 #[serde(tag = "type", rename = "Feature")]
 pub struct Item {
     /// The STAC version the `Item` implements.
@@ -570,15 +570,6 @@ impl Assets for Item {
     }
     fn assets_mut(&mut self) -> &mut HashMap<String, Asset> {
         &mut self.assets
-    }
-}
-
-impl Fields for Item {
-    fn fields(&self) -> &Map<String, Value> {
-        &self.properties.additional_fields
-    }
-    fn fields_mut(&mut self) -> &mut Map<String, Value> {
-        &mut self.properties.additional_fields
     }
 }
 


### PR DESCRIPTION
## Closes

- #543

## Related to

- #542

## Description

Replace manual implementation of `Fields` trait for `Item` with `#[derive(Fields)]`

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [ ] Unit tests
- [ ] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [ ] Changes are added to the CHANGELOG

<!-- markdownlint-disable-file MD041 -->
