### PR TITLE
feat: CLI list possible values for format options.

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- List available i/o formats in help ([#549](https://github.com/stac-utils/stac-rs/pull/549))
+
 ## [0.4.1] - 2024-10-22
 
 ### Changed

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -390,7 +390,7 @@ impl From<FormatWrapper> for Format {
     fn from(wrapper: FormatWrapper) -> Self {
         match wrapper {
             FormatWrapper::Json => Format::json(),
-            FormatWrapper::Ndkson => Format::ndjson(),
+            FormatWrapper::Ndjson => Format::ndjson(),
             FormatWrapper::Geoparquet => Format::geoparquet(),
         }
     }


### PR DESCRIPTION
## Closes

- #413

## Description

`clap` has a `ValueEnum` trait that gives better help messages for you.
Since `Format` is in a different crate, I can not add an `impl` of this trait for it.
I also do not want to have `clap` in core.
So, I created a wrapper that has a needed trait and then converts into `Format`

Here is how it looks:
```
❯ cargo run --
...
Command line interface for stac-rs

Usage: stacrs [OPTIONS] <COMMAND>

Commands:
  [...]
  help       Print this message or the help of the given subcommand(s)

Options:
  -i, --input-format <INPUT_FORMAT>     The input format, if not provided will be inferred from the input file's extension, falling back to json [possible values: json, ndjson, geoparquet]
      --input-option <INPUT_OPTIONS>    key=value pairs to use for the input object store
  -o, --output-format <OUTPUT_FORMAT>   The output format, if not provided will be inferred from the output file's extension, falling back to json [possible values: json, ndjson, geoparquet]

```

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [ ] Unit tests
- [ ] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG

<!-- markdownlint-disable-file MD041 -->
