### PR TITLE
refactor(pgstac): return json, not stac

### DIFF
--- a/crates/pgstac/CHANGELOG.md
+++ b/crates/pgstac/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Return JSON, not STAC ([#550](https://github.com/stac-utils/stac-rs/pull/550))
+
 ## [0.2.2] - 2024-11-12
 
 Bump dependencies.

--- a/crates/pgstac/src/lib.rs
+++ b/crates/pgstac/src/lib.rs
@@ -77,3 +77,6 @@ pub enum Error {
 
 /// Crate-specific result type.
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// A [serde_json::Value].
+pub type JsonValue = serde_json::Value;

--- a/crates/server/src/backend/pgstac.rs
+++ b/crates/server/src/backend/pgstac.rs
@@ -104,7 +104,7 @@ where
         let client = Client::new(&*client);
         let value = client.collection(id).await?;
         value
-            .map(|v| serde_json::from_value(v))
+            .map(serde_json::from_value)
             .transpose()
             .map_err(Error::from)
     }


### PR DESCRIPTION
This makes it easier to use in upstream Python bindings
