### PR TITLE
release(stac-server): remove stac-types dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ mime = "0.3.17"
 mockito = "1.5"
 object_store = "0.11.0"
 parquet = { version = "53.1.0", default-features = false }
-pgstac = { version = "0.2.2", path = "crates/pgstac" }
+pgstac = { version = "0.3.0", path = "crates/pgstac" }
 pyo3 = "0.23.3"
 pythonize = "0.23.0"
 quote = "1.0"

--- a/crates/pgstac/CHANGELOG.md
+++ b/crates/pgstac/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-01-14
+
 ### Added
 
 - `Pgstac` trait ([#551](https://github.com/stac-utils/stac-rs/pull/551))
@@ -90,7 +92,8 @@ Bump dependencies.
 
 Initial release
 
-[unreleased]: https://github.com/stac-utils/stac-rs/compare/pgstac-v0.2.2...HEAD
+[unreleased]: https://github.com/stac-utils/stac-rs/compare/pgstac-v0.3.0...HEAD
+[0.3.0]: https://github.com/stac-utils/stac-rs/compare/pgstac-v0.2.2..pgstac-v0.3.0
 [0.2.2]: https://github.com/stac-utils/stac-rs/compare/pgstac-v0.2.1..pgstac-v0.2.2
 [0.2.1]: https://github.com/stac-utils/stac-rs/compare/pgstac-v0.2.0..pgstac-v0.2.1
 [0.2.0]: https://github.com/stac-utils/stac-rs/compare/pgstac-v0.1.2..pgstac-v0.2.0

--- a/crates/pgstac/Cargo.toml
+++ b/crates/pgstac/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgstac"
 description = "Rust interface for pgstac"
-version = "0.2.2"
+version = "0.3.0"
 keywords = ["geospatial", "stac", "metadata", "raster", "database"]
 categories = ["database", "data-structures", "science"]
 authors.workspace = true

--- a/crates/pgstac/README.md
+++ b/crates/pgstac/README.md
@@ -13,7 +13,7 @@ In your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pgstac = "0.2"
+pgstac = "0.3"
 ```
 
 See the [documentation](https://docs.rs/pgstac) for more.

--- a/crates/server/CHANGELOG.md
+++ b/crates/server/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.3.3] - 2025-01-14
+
+- **stac-types** dependency ([#561](https://github.com/stac-utils/stac-rs/pull/561))
+
 ## [0.3.2] - 2024-11-12
 
 ### Added

--- a/crates/server/CHANGELOG.md
+++ b/crates/server/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [0.3.3] - 2025-01-14
 
+### Removed
+
 - **stac-types** dependency ([#561](https://github.com/stac-utils/stac-rs/pull/561))
 
 ## [0.3.2] - 2024-11-12
@@ -61,7 +63,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Initial release.
 
-[Unreleased]: https://github.com/stac-utils/stac-rs/compare/stac-server-v0.3.2..main
+[Unreleased]: https://github.com/stac-utils/stac-rs/compare/stac-server-v0.3.3..main
+[0.3.3]: https://github.com/stac-utils/stac-rs/compare/stac-server-v0.3.2..stac-server-v0.3.3
 [0.3.2]: https://github.com/stac-utils/stac-rs/compare/stac-server-v0.3.1..stac-server-v0.3.2
 [0.3.1]: https://github.com/stac-utils/stac-rs/compare/stac-server-v0.3.0..stac-server-v0.3.1
 [0.3.0]: https://github.com/stac-utils/stac-rs/compare/stac-server-v0.2.0..stac-server-v0.3.0

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stac-server"
 description = "SpatioTemporal Asset Catalog (STAC) API server"
-version = "0.3.2"
+version = "0.3.3"
 keywords = ["geospatial", "stac", "metadata", "geo", "server"]
 categories = ["science", "data-structures"]
 edition.workspace = true


### PR DESCRIPTION
## Closes

No open issue but the change in the PR added to the CHANGELOG should have triggered a release of stac-server. The current release contains the yanked `stac-types` crate which is breaking our build.

## Description

No code changes, just a note to trigger a release

## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Commit messages are descriptive
- [x] (optional) Git commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes are added to the CHANGELOG

<!-- markdownlint-disable-file MD041 -->
