### PR TITLE
feat: add method to fetch required DuckDB extensions

### DIFF
--- a/crates/duckdb/CHANGELOG.md
+++ b/crates/duckdb/CHANGELOG.md
@@ -13,10 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Client.search_to_arrow_table` ([#634](https://github.com/stac-utils/stac-rs/pull/634))
 - Conditionally disable parsing the WKB ([#635](https://github.com/stac-utils/stac-rs/pull/635))
 - `Client.extensions` ([#665](https://github.com/stac-utils/stac-rs/pull/665))
+- `Client::fetch_extensions` to install extensions ([#666](https://github.com/stac-utils/stac-rs/pull/666))
 
 ### Removed
 
 - geoarrow record batch converters (moved to **stac**) ([#652](https://github.com/stac-utils/stac-rs/pull/652))
+- `Client::new` no longer installs extensions ([#666](https://github.com/stac-utils/stac-rs/pull/666))
 
 ## [0.1.1] - 2025-01-31
 


### PR DESCRIPTION
## Closes

- https://github.com/stac-utils/stac-rs/issues/655

## Description

This PR attempts to address some user experience goals related to DuckDB extensions by adding a way for the `Client` to install whatever DuckDB extensions are required for use. This extension list can be categorized into,

* "core" dependencies that `stac-rs` needs ("icu" and "spatial")
* "optional" dependencies that `stac-rs` **might** need depending on the location of the STAC GeoParquet assets. For example,
    * If on local disk we don't need AWS or Azure or HTTPFS
    * If on a remote server or GCP we need HTTPFS but not AWS or Azure
    * If on AWS _and_ we want to use the credential provider, we need AWS extension AND HTTPFS
    * If on Azure we need Azure but not HTTPFS or AWS

Once installed DuckDB will "[autoload](https://duckdb.org/docs/stable/extensions/core_extensions.html#list-of-core-extensions)" (see "autoloadable" column) the extensions for AWS/Azure/HTTPFS as needed, so we don't need to invoke that in our `Client::new`. By contrast "spatial" is NOT autoloadable, so that still has to live in `Client::new`

The formatting at least for docs looks good to me (feel free to suggest wording / example cases),
![image](https://github.com/user-attachments/assets/1098be72-8c32-440b-a86e-76a936dc50f0)


## Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Documentation, including doctests
- [x] Git history is linear
- [x] Commit messages are descriptive
- [x] Code is formatted (`cargo fmt`)
- [x] `cargo test`
- [x] Changes are added to the CHANGELOG