### PR TITLE
feat(cli): optionally disable tracing subscriber init

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -257,10 +257,15 @@ struct ErrorLevel;
 
 impl Stacrs {
     /// Runs this command.
-    pub async fn run(self) -> Result<()> {
-        tracing_subscriber::fmt()
-            .with_max_level(self.log_level())
-            .init();
+    ///
+    /// If `init_tracing_subscriber` is `false`, it is expected that the caller
+    /// is setting up the appropriate logging (e.g. Python).
+    pub async fn run(self, init_tracing_subscriber: bool) -> Result<()> {
+        if init_tracing_subscriber {
+            tracing_subscriber::fmt()
+                .with_max_level(self.log_level())
+                .init();
+        }
         match self.command {
             Command::Translate {
                 ref infile,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,7 +4,7 @@ use stac_cli::Stacrs;
 #[tokio::main]
 async fn main() {
     let args = Stacrs::parse();
-    std::process::exit(match args.run().await {
+    std::process::exit(match args.run(true).await {
         Ok(()) => 0,
         Err(err) => {
             eprintln!("ERROR: {}", err);


### PR DESCRIPTION
This lets us _not_ do it over in Python, and instead set up our own logging.