### PR TITLE
refactor: don't put local crates in workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ mime = "0.3.17"
 mockito = "1.5"
 object_store = "0.12.0"
 parquet = { version = "56.0.0" }
-pgstac = { version = "0.3.0", path = "crates/pgstac" }
 quote = "1.0"
 reqwest = { version = "0.12.8", default-features = false, features = [
     "rustls-tls",
@@ -86,13 +85,6 @@ rustls = { version = "0.23.22", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"
-stac = { version = "0.14.0", path = "crates/core" }
-stac-derive = { version = "0.3.0", path = "crates/derive" }
-stac-duckdb = { version = "0.2.0", path = "crates/duckdb" }
-stac-extensions = { version = "0.1.0", path = "crates/extensions" }
-stac-io = { version = "0.1.0", path = "crates/io" }
-stac-server = { version = "0.3.2", path = "crates/server" }
-stac-validate = { version = "0.5.0", path = "crates/validate" }
 syn = "2.0"
 tempfile = "3.16"
 thiserror = "2.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,14 +25,14 @@ clap_complete.workspace = true
 futures-core.workspace = true
 futures-util.workspace = true
 serde_json.workspace = true
-stac.workspace = true
-stac-duckdb.workspace = true
-stac-io = { workspace = true, features = [
+stac = { version = "0.14.0", path = "../core" }
+stac-duckdb = { version = "0.2.0", path = "../duckdb" }
+stac-io = { version = "0.1.0", path = "../io", features = [
     "store-all",
     "geoparquet",
 ] }
-stac-server = { workspace = true, features = ["axum", "duckdb"] }
-stac-validate.workspace = true
+stac-server = { version = "0.3.2", path = "../server", features = ["axum", "duckdb"] }
+stac-validate = { version = "0.5.0", path = "../validate" }
 tokio = { workspace = true, features = [
     "macros",
     "io-std",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -48,7 +48,7 @@ parquet = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded.workspace = true
-stac-derive.workspace = true
+stac-derive = { version = "0.3.0", path = "../derive" }
 thiserror.workspace = true
 tracing.workspace = true
 url = { workspace = true, features = ["serde"] }

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -27,11 +27,11 @@ geojson.workspace = true
 getrandom.workspace = true
 log.workspace = true
 serde_json.workspace = true
-stac = { workspace = true, features = ["geoarrow", "geo"] }
+stac = { version = "0.14.0", path = "../core", features = ["geoarrow", "geo"] }
 thiserror.workspace = true
 
 [dev-dependencies]
 geo.workspace = true
 rstest.workspace = true
-stac-validate = { path = "../validate" }
+stac-validate = { version = "0.5.0", path = "../validate" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/extensions/Cargo.toml
+++ b/crates/extensions/Cargo.toml
@@ -16,4 +16,4 @@ geojson.workspace = true
 indexmap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-stac.workspace = true
+stac = { version = "0.14.0", path = "../core" }

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -31,7 +31,7 @@ parquet = { workspace = true, optional = true, features = ["arrow", "async", "ob
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
-stac.workspace = true
+stac = { version = "0.14.0", path = "../core" }
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/pgstac/Cargo.toml
+++ b/crates/pgstac/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-stac.workspace = true
+stac = { version = "0.14.0", path = "../core" }
 thiserror.workspace = true
 tokio-postgres = { workspace = true, features = ["with-serde_json-1"] }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -30,13 +30,13 @@ bb8-postgres = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 http.workspace = true
 mime = { workspace = true, optional = true }
-pgstac = { workspace = true, optional = true }
+pgstac = { version = "0.3.0", path = "../pgstac", optional = true }
 rustls = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
-stac.workspace = true
-stac-duckdb = { workspace = true, optional = true }
+stac = { version = "0.14.0", path = "../core" }
+stac-duckdb = { version = "0.2.0", path = "../duckdb", optional = true }
 thiserror.workspace = true
 tokio-postgres = { workspace = true, optional = true }
 tokio-postgres-rustls = { workspace = true, optional = true }

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -17,13 +17,13 @@ jsonschema.workspace = true
 reqwest = { workspace = true, features = ["blocking", "json"] }
 serde.workspace = true
 serde_json.workspace = true
-stac.workspace = true
+stac = { version = "0.14.0", path = "../core" }
 thiserror.workspace = true
 async-trait.workspace = true
 referencing.workspace = true
 async-recursion.workspace = true
 
 [dev-dependencies]
-stac-io.workspace = true
+stac-io = { version = "0.1.0", path = "../io" }
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -21,7 +21,7 @@ arrow-schema.workspace = true
 arrow-wasm = { git = "https://github.com/kylebarron/arrow-wasm", rev = "6da94ef0a1522a244984a7d3d58a0339d0851d96" }
 serde.workspace = true
 serde-wasm-bindgen = "0.6.5"
-stac = { workspace = true, features = ["geoparquet"] }
+stac = { version = "0.14.0", path = "../core", features = ["geoparquet"] }
 thiserror.workspace = true
 wasm-bindgen = "0.2.84"
 


### PR DESCRIPTION
This is a thing the 🤖 is good for doing for us.