### PR TITLE
feat: add search_with_headers

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -453,7 +453,8 @@ impl Rustac {
                     }
                     SearchImplementation::Duckdb => stac_duckdb::search(href, search, *max_items)?,
                     SearchImplementation::Api => {
-                        stac_io::api::search(href, search, *max_items, &headers).await?
+                        stac_io::api::search_with_headers(href, search, *max_items, &headers)
+                            .await?
                     }
                 };
                 self.put(

--- a/crates/io/src/api.rs
+++ b/crates/io/src/api.rs
@@ -21,6 +21,15 @@ const DEFAULT_CHANNEL_BUFFER: usize = 4;
 /// Searches a STAC API.
 pub async fn search(
     href: &str,
+    search: Search,
+    max_items: Option<usize>,
+) -> Result<ItemCollection> {
+    search_with_headers(href, search, max_items, &[]).await
+}
+
+/// Searches a STAC API with the provided headers.
+pub async fn search_with_headers(
+    href: &str,
     mut search: Search,
     max_items: Option<usize>,
     headers: &[(String, String)],


### PR DESCRIPTION
This also fixes a API-breaking change to the `search` signature.