### PR TITLE
fix(docs): correct description of into_cql2_text

### DIFF
--- a/crates/core/src/api/filter.rs
+++ b/crates/core/src/api/filter.rs
@@ -32,7 +32,7 @@ impl Filter {
         }
     }
 
-    /// Converts this filter to cql2-json.
+    /// Converts this filter to cql2-text.
     pub fn into_cql2_text(self) -> Result<Filter> {
         match self {
             Filter::Cql2Text(_) => Ok(self),


### PR DESCRIPTION
### Description

Tiny docs patch -- into_cql2_json and into_cql2_text have the same docstring

### Checklist

Delete any checklist items that do not apply (e.g. if your change is minor, it may not require documentation updates).

- [x] Documentation, including doctests
- [x] Pull request title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
